### PR TITLE
:sparkles: Add only ingress mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ See the wiki for the different feature sets available.
     -n, --no-contaminant-features
             Whether not to include contaminant features
 
+    -o, --only-ingress
+            Only ingress traffic will be captured
+
         --interval <INTERVAL>
             The print interval for open flows in seconds, needs to be smaller than the flow maximum lifespan
 

--- a/feature-extraction-tool/src/args.rs
+++ b/feature-extraction-tool/src/args.rs
@@ -24,6 +24,10 @@ pub enum Commands {
         #[clap(short, long, action = clap::ArgAction::SetTrue)]
         no_contaminant_features: bool,
 
+        /// Only ingress traffic will be captured
+        #[clap(short, long, action = clap::ArgAction::SetTrue)]
+        only_ingress: bool,
+
         /// Output method
         #[clap(flatten)]
         export_method: Output,


### PR DESCRIPTION
Added possibility to only run the tool in ingress only mode. Only ingress traffic is then processed.

closes #38 