### PR TITLE
🚚 Remove reference old project name 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY .cargo ./.cargo
 COPY common ./common
-COPY feature-extraction-tool ./feature-extraction-tool
+COPY rustiflow ./rustiflow
 COPY xtask ./xtask
 COPY rustfmt.toml .
 COPY ebpf-ipv4 ./ebpf-ipv4

--- a/ebpf-ipv4/Cargo.toml
+++ b/ebpf-ipv4/Cargo.toml
@@ -10,7 +10,7 @@ common = { path = "../common" }
 network-types = "0.0.5"
 
 [[bin]]
-name = "feature-extraction-tool-ipv4"
+name = "rustiflow-ebpf-ipv4"
 path = "src/main.rs"
 
 [profile.dev]

--- a/ebpf-ipv6/Cargo.toml
+++ b/ebpf-ipv6/Cargo.toml
@@ -10,7 +10,7 @@ common = { path = "../common" }
 network-types = "0.0.5"
 
 [[bin]]
-name = "feature-extraction-tool-ipv6"
+name = "rustiflow-ebpf-ipv6"
 path = "src/main.rs"
 
 [profile.dev]

--- a/rustiflow/src/main.rs
+++ b/rustiflow/src/main.rs
@@ -324,39 +324,39 @@ where
     // Loading the eBPF program for egress, the macros make sure the correct file is loaded
     #[cfg(debug_assertions)]
     let mut bpf_egress_ipv4 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/feature-extraction-tool-ipv4"
+        "../../target/bpfel-unknown-none/debug/rustiflow-ebpf-ipv4"
     ))?;
     #[cfg(not(debug_assertions))]
     let mut bpf_egress_ipv4 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/release/feature-extraction-tool-ipv4"
+        "../../target/bpfel-unknown-none/release/rustiflow-ebpf-ipv4"
     ))?;
 
     #[cfg(debug_assertions)]
     let mut bpf_egress_ipv6 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/feature-extraction-tool-ipv6"
+        "../../target/bpfel-unknown-none/debug/rustiflow-ebpf-ipv6"
     ))?;
     #[cfg(not(debug_assertions))]
     let mut bpf_egress_ipv6 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/release/feature-extraction-tool-ipv6"
+        "../../target/bpfel-unknown-none/release/rustiflow-ebpf-ipv6"
     ))?;
 
     // Loading the eBPF program for ingress, the macros make sure the correct file is loaded
     #[cfg(debug_assertions)]
     let mut bpf_ingress_ipv4 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/feature-extraction-tool-ipv4"
+        "../../target/bpfel-unknown-none/debug/rustiflow-ebpf-ipv4"
     ))?;
     #[cfg(not(debug_assertions))]
     let mut bpf_ingress_ipv4 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/release/feature-extraction-tool-ipv4"
+        "../../target/bpfel-unknown-none/release/rustiflow-ebpf-ipv4"
     ))?;
 
     #[cfg(debug_assertions)]
     let mut bpf_ingress_ipv6 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/debug/feature-extraction-tool-ipv6"
+        "../../target/bpfel-unknown-none/debug/rustiflow-ebpf-ipv6"
     ))?;
     #[cfg(not(debug_assertions))]
     let mut bpf_ingress_ipv6 = Ebpf::load(include_bytes_aligned!(
-        "../../target/bpfel-unknown-none/release/feature-extraction-tool-ipv6"
+        "../../target/bpfel-unknown-none/release/rustiflow-ebpf-ipv6"
     ))?;
 
     if !only_ingress {


### PR DESCRIPTION
Docker build was failing due to using old generic project name