### PR TITLE
Slim dockerimage

### DIFF
--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -5,7 +5,6 @@ FROM rust:latest AS builder
 RUN apt-get update && apt-get install -y \
     libpcap-dev \
     iproute2 \
-    # linux-headers \
     && rustup toolchain install stable \
     && rustup toolchain install nightly --component rust-src \
     && cargo install bpf-linker \
@@ -37,7 +36,6 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y \
     libpcap0.8 \
     iproute2 \
-    # linux-tools-$(uname -r) \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get install -y \
 
 # Set environment variables
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV RUST_LOG=info
 
 # Copy source code
 WORKDIR /usr/src/app

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,0 +1,52 @@
+# Stage 1: Build
+FROM rust:latest AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    libpcap-dev \
+    iproute2 \
+    # linux-headers \
+    && rustup toolchain install stable \
+    && rustup toolchain install nightly --component rust-src \
+    && cargo install bpf-linker \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment variables
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV RUST_LOG=info
+
+# Copy source code
+WORKDIR /usr/src/app
+COPY Cargo.toml Cargo.lock ./
+COPY .cargo ./.cargo
+COPY common ./common
+COPY rustiflow ./rustiflow
+COPY xtask ./xtask
+COPY rustfmt.toml .
+COPY ebpf-ipv4 ./ebpf-ipv4
+COPY ebpf-ipv6 ./ebpf-ipv6
+
+# Build the project
+RUN cargo xtask ebpf-ipv4 --release && \
+    cargo xtask ebpf-ipv6 --release && \
+    cargo build --release
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libpcap0.8 \
+    iproute2 \
+    # linux-tools-$(uname -r) \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the compiled binaries from the builder stage
+COPY --from=builder /usr/src/app/target/release/rustiflow /usr/local/bin/rustiflow
+
+# Set environment variables
+ENV RUST_LOG=info
+
+# Command
+ENTRYPOINT ["rustiflow"]


### PR DESCRIPTION
Create dockerfile for minimal docker image.
- multi-stage build
- changed base image from ubuntu:20.04 -> debian:bookworm-slim
- reduced size from 3.71GB to 96MB