### PR TITLE
:bug: Fix timestamp of packet

### DIFF
--- a/rustiflow/src/flows/basic_flow.rs
+++ b/rustiflow/src/flows/basic_flow.rs
@@ -75,6 +75,7 @@ impl Flow for BasicFlow {
         ip_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
+        ts_date: DateTime<Utc>,
     ) -> Self {
         BasicFlow {
             flow_id,
@@ -83,8 +84,8 @@ impl Flow for BasicFlow {
             port_destination,
             port_source,
             protocol,
-            first_timestamp: Utc::now(),
-            last_timestamp: Utc::now(),
+            first_timestamp: ts_date,
+            last_timestamp: ts_date,
             flow_end_of_flow_ack: 0,
             fwd_fin_flag_count: 0,
             fwd_syn_flag_count: 0,
@@ -111,9 +112,10 @@ impl Flow for BasicFlow {
         &mut self,
         packet: &BasicFeatures,
         _timestamp: &Instant,
+        ts_date: DateTime<Utc>,
         fwd: bool,
     ) -> Option<String> {
-        self.last_timestamp = Utc::now();
+        self.last_timestamp = ts_date;
 
         // when both FIN flags are set, the flow can be finished when the last ACK is received
         if self.fwd_fin_flag_count > 0 && self.bwd_fin_flag_count > 0 {

--- a/rustiflow/src/flows/cic_flow.rs
+++ b/rustiflow/src/flows/cic_flow.rs
@@ -1098,6 +1098,7 @@ impl Flow for CicFlow {
         ipv4_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
+        ts_date: DateTime<Utc>,
     ) -> Self {
         CicFlow {
             basic_flow: BasicFlow::new(
@@ -1107,6 +1108,7 @@ impl Flow for CicFlow {
                 ipv4_destination,
                 port_destination,
                 protocol,
+                ts_date,
             ),
             sf_last_packet_timestamp: None,
             sf_count: 0,
@@ -1175,9 +1177,10 @@ impl Flow for CicFlow {
         &mut self,
         packet: &BasicFeatures,
         timestamp: &Instant,
+        ts_date: DateTime<Utc>,
         fwd: bool,
     ) -> Option<String> {
-        self.basic_flow.update_flow(packet, timestamp, fwd);
+        self.basic_flow.update_flow(packet, timestamp, ts_date, fwd);
         self.update_subflows(timestamp);
 
         if fwd {
@@ -1439,6 +1442,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::from(2)),
             8080,
             6,
+            chrono::Utc::now(),
         )
     }
 
@@ -2235,6 +2239,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::from(2)),
             8080,
             6,
+            chrono::Utc::now(),
         );
         let packet = BasicFeatures {
             fin_flag: 1,
@@ -2252,7 +2257,7 @@ mod tests {
         };
         let timestamp = Instant::now();
 
-        cic_flow.update_flow(&packet, &timestamp, true);
+        cic_flow.update_flow(&packet, &timestamp, chrono::Utc::now() , true);
 
         assert_eq!(cic_flow.basic_flow.fwd_packet_count, 1);
         assert_eq!(cic_flow.basic_flow.bwd_packet_count, 0);
@@ -2309,6 +2314,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::from(2)),
             8080,
             6,
+            chrono::Utc::now(),
         );
         let packet = BasicFeatures {
             fin_flag: 1,
@@ -2326,7 +2332,7 @@ mod tests {
         };
         let timestamp = Instant::now();
 
-        cic_flow.update_flow(&packet, &timestamp, false);
+        cic_flow.update_flow(&packet, &timestamp, chrono::Utc::now(), false);
 
         assert_eq!(cic_flow.basic_flow.fwd_packet_count, 0);
         assert_eq!(cic_flow.basic_flow.bwd_packet_count, 1);
@@ -2383,6 +2389,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::from(2)),
             8080,
             6,
+            chrono::Utc::now(),
         );
         let packet_1 = BasicFeatures {
             fin_flag: 1,
@@ -2400,7 +2407,7 @@ mod tests {
         };
         let timestamp_1 = Instant::now();
 
-        cic_flow.update_flow(&packet_1, &timestamp_1, true);
+        cic_flow.update_flow(&packet_1, &timestamp_1, chrono::Utc::now(), true);
 
         std::thread::sleep(std::time::Duration::from_secs(1));
 
@@ -2420,7 +2427,7 @@ mod tests {
         };
         let timestamp_2 = Instant::now();
 
-        cic_flow.update_flow(&packet_2, &timestamp_2, true);
+        cic_flow.update_flow(&packet_2, &timestamp_2, chrono::Utc::now(), true);
 
         assert_eq!(cic_flow.basic_flow.fwd_packet_count, 2);
         assert_eq!(cic_flow.basic_flow.bwd_packet_count, 0);
@@ -2489,6 +2496,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::from(2)),
             8080,
             6,
+            chrono::Utc::now(),
         );
         let packet_1 = BasicFeatures {
             fin_flag: 1,
@@ -2506,7 +2514,7 @@ mod tests {
         };
         let timestamp_1 = Instant::now();
 
-        cic_flow.update_flow(&packet_1, &timestamp_1, false);
+        cic_flow.update_flow(&packet_1, &timestamp_1, chrono::Utc::now(), false);
 
         std::thread::sleep(std::time::Duration::from_secs(1));
 
@@ -2526,7 +2534,7 @@ mod tests {
         };
         let timestamp_2 = Instant::now();
 
-        cic_flow.update_flow(&packet_2, &timestamp_2, false);
+        cic_flow.update_flow(&packet_2, &timestamp_2, chrono::Utc::now(), false);
 
         assert_eq!(cic_flow.basic_flow.fwd_packet_count, 0);
         assert_eq!(cic_flow.basic_flow.bwd_packet_count, 2);

--- a/rustiflow/src/flows/cidds_flow.rs
+++ b/rustiflow/src/flows/cidds_flow.rs
@@ -70,6 +70,7 @@ impl Flow for CiddsFlow {
         ipv4_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
+        ts_date: DateTime<Utc>,
     ) -> Self {
         CiddsFlow {
             basic_flow: BasicFlow::new(
@@ -79,6 +80,7 @@ impl Flow for CiddsFlow {
                 ipv4_destination,
                 port_destination,
                 protocol,
+                ts_date,
             ),
             bytes: 0,
         }
@@ -88,9 +90,10 @@ impl Flow for CiddsFlow {
         &mut self,
         packet: &BasicFeatures,
         timestamp: &Instant,
+        ts_date: DateTime<Utc>,
         fwd: bool,
     ) -> Option<String> {
-        self.basic_flow.update_flow(packet, timestamp, fwd);
+        self.basic_flow.update_flow(packet, timestamp, ts_date, fwd);
 
         self.bytes += packet.length as u32;
 
@@ -178,6 +181,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::from(2)),
             8080,
             6,
+            chrono::Utc::now(),
         )
     }
 

--- a/rustiflow/src/flows/custom_flow.rs
+++ b/rustiflow/src/flows/custom_flow.rs
@@ -25,6 +25,7 @@ impl Flow for CustomFlow {
         ipv4_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
+        ts_date: DateTime<Utc>,
     ) -> Self {
         CustomFlow {
             basic_flow: BasicFlow::new(
@@ -34,6 +35,7 @@ impl Flow for CustomFlow {
                 ipv4_destination,
                 port_destination,
                 protocol,
+                ts_date
             ),
             // Add here the initialization of the additional features.
         }
@@ -43,9 +45,10 @@ impl Flow for CustomFlow {
         &mut self,
         packet: &BasicFeatures,
         timestamp: &Instant,
+        ts_date: DateTime<Utc>,
         fwd: bool,
     ) -> Option<String> {
-        self.basic_flow.update_flow(packet, timestamp, fwd);
+        self.basic_flow.update_flow(packet, timestamp, ts_date, fwd);
 
         // Add here the update of the additional features.
 

--- a/rustiflow/src/flows/flow.rs
+++ b/rustiflow/src/flows/flow.rs
@@ -33,6 +33,7 @@ pub trait Flow {
         ipv4_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
+        ts_date: DateTime<Utc>,
     ) -> Self;
 
     /// Updates the flow with a new packet.
@@ -54,6 +55,7 @@ pub trait Flow {
         &mut self,
         packet: &BasicFeatures,
         timestamp: &Instant,
+        ts_date: DateTime<Utc>,
         fwd: bool,
     ) -> Option<String>;
 

--- a/rustiflow/src/flows/nf_flow.rs
+++ b/rustiflow/src/flows/nf_flow.rs
@@ -31,6 +31,7 @@ impl Flow for NfFlow {
         ipv4_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
+        ts_date: DateTime<Utc>,
     ) -> Self {
         NfFlow {
             cic_flow: CicFlow::new(
@@ -40,13 +41,14 @@ impl Flow for NfFlow {
                 ipv4_destination,
                 port_destination,
                 protocol,
+                ts_date,
             ),
-            first_timestamp: SystemTime::now(),
-            last_timestamp: SystemTime::now(),
-            fwd_first_timestamp: SystemTime::now(),
-            fwd_last_timestamp: SystemTime::now(),
-            bwd_first_timestamp: SystemTime::now(),
-            bwd_last_timestamp: SystemTime::now(),
+            first_timestamp: ts_date.into(),
+            last_timestamp: ts_date.into(),
+            fwd_first_timestamp: ts_date.into(),
+            fwd_last_timestamp: ts_date.into(),
+            bwd_first_timestamp: ts_date.into(),
+            bwd_last_timestamp: ts_date.into(),
         }
     }
 
@@ -54,15 +56,16 @@ impl Flow for NfFlow {
         &mut self,
         packet: &BasicFeatures,
         timestamp: &Instant,
+        ts_date: DateTime<Utc>,
         fwd: bool,
     ) -> Option<String> {
         if fwd {
-            self.fwd_last_timestamp = SystemTime::now();
+            self.fwd_last_timestamp = ts_date.into();
         } else {
-            self.bwd_last_timestamp = SystemTime::now();
+            self.bwd_last_timestamp = ts_date.into();
         }
 
-        let end = self.cic_flow.update_flow(packet, timestamp, fwd);
+        let end = self.cic_flow.update_flow(packet, timestamp, ts_date, fwd);
         if end.is_some() {
             if *NO_CONTAMINANT_FEATURES.lock().unwrap().deref() {
                 return Some(self.dump_without_contamination());

--- a/rustiflow/src/flows/ntl_flow.rs
+++ b/rustiflow/src/flows/ntl_flow.rs
@@ -235,6 +235,7 @@ impl Flow for NTLFlow {
         ipv4_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
+        ts_date: DateTime<Utc>,
     ) -> Self {
         NTLFlow {
             basic_flow: CicFlow::new(
@@ -244,6 +245,7 @@ impl Flow for NTLFlow {
                 ipv4_destination,
                 port_destination,
                 protocol,
+                ts_date,
             ),
             fwd_header_len_min: u32::MAX,
             fwd_header_len_max: 0,
@@ -260,9 +262,10 @@ impl Flow for NTLFlow {
         &mut self,
         packet: &BasicFeatures,
         timestamp: &Instant,
+        ts_date: DateTime<Utc>,
         fwd: bool,
     ) -> Option<String> {
-        let end = self.basic_flow.update_flow(packet, timestamp, fwd);
+        let end = self.basic_flow.update_flow(packet, timestamp, ts_date, fwd);
 
         if fwd {
             self.update_fwd_header_len_stats(packet.header_length as u32);
@@ -645,6 +648,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::from(2)),
             8080,
             6,
+            chrono::Utc::now(),
         )
     }
 

--- a/rustiflow/src/main.rs
+++ b/rustiflow/src/main.rs
@@ -41,6 +41,7 @@ use std::{
     io::{BufWriter, Read, Write},
     ops::{Deref, DerefMut},
     sync::atomic::{AtomicUsize, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
 };
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
@@ -451,7 +452,7 @@ where
                     let ptr = buf.as_ptr() as *const BasicFeaturesIpv4;
                     let data = unsafe { ptr.read_unaligned() };
 
-                    process_packet_ipv4(&data, &flow_map_clone_egress_ipv4, false);
+                    process_packet_ipv4(&data, &flow_map_clone_egress_ipv4, false, None);
                 }
             }
         });
@@ -473,7 +474,7 @@ where
                     let ptr = buf.as_ptr() as *const BasicFeaturesIpv4;
                     let data = unsafe { ptr.read_unaligned() };
 
-                    process_packet_ipv4(&data, &flow_map_clone_ingress_ipv4, true);
+                    process_packet_ipv4(&data, &flow_map_clone_ingress_ipv4, true, None);
                 }
             }
         });
@@ -496,7 +497,7 @@ where
                     let ptr = buf.as_ptr() as *const BasicFeaturesIpv6;
                     let data = unsafe { ptr.read_unaligned() };
 
-                    process_packet_ipv6(&data, &flow_map_clone_egress_ipv6, false);
+                    process_packet_ipv6(&data, &flow_map_clone_egress_ipv6, false, None);
                 }
             }
         });
@@ -518,7 +519,7 @@ where
                     let ptr = buf.as_ptr() as *const BasicFeaturesIpv6;
                     let data = unsafe { ptr.read_unaligned() };
 
-                    process_packet_ipv6(&data, &flow_map_clone_ingress_ipv6, true);
+                    process_packet_ipv6(&data, &flow_map_clone_ingress_ipv6, true, None);
                 }
             }
         });
@@ -668,6 +669,21 @@ where
     };
 
     while let Ok(packet) = cap.next_packet() {
+        let ts = packet.header.ts;
+
+        let system_time = timeval_to_system_time(ts.tv_sec, ts.tv_usec);
+        let now = SystemTime::now();
+
+        let elapsed_duration = match now.duration_since(system_time) {
+            Ok(duration) => duration,
+            Err(e) => {
+                error!("Error calculating duration: {:?}", e);
+                Duration::new(0, 0)
+            }
+        };
+
+        let ts_instant = Instant::now() - elapsed_duration;
+
         if let Some(ethernet) = EthernetPacket::new(packet.data) {
             match ethernet.get_ethertype() {
                 EtherTypes::Ipv4 => {
@@ -677,7 +693,7 @@ where
                             if amount_of_packets % 10_000 == 0 {
                                 info!("{} packets have been processed...", amount_of_packets);
                             }
-                            redirect_packet_ipv4(&features_ipv4, &flow_map_ipv4);
+                            redirect_packet_ipv4(&features_ipv4, &flow_map_ipv4, ts_instant);
                         }
                     }
                 }
@@ -688,7 +704,7 @@ where
                             if amount_of_packets % 10_000 == 0 {
                                 info!("{} packets have been processed...", amount_of_packets);
                             }
-                            redirect_packet_ipv6(&features_ipv6, &flow_map_ipv6);
+                            redirect_packet_ipv6(&features_ipv6, &flow_map_ipv6, ts_instant);
                         }
                     }
                 }
@@ -705,7 +721,11 @@ where
                                             amount_of_packets
                                         );
                                     }
-                                    redirect_packet_ipv4(&features_ipv4, &flow_map_ipv4);
+                                    redirect_packet_ipv4(
+                                        &features_ipv4,
+                                        &flow_map_ipv4,
+                                        ts_instant,
+                                    );
                                 }
                             }
                         }
@@ -719,7 +739,11 @@ where
                                             amount_of_packets
                                         );
                                     }
-                                    redirect_packet_ipv6(&features_ipv6, &flow_map_ipv6);
+                                    redirect_packet_ipv6(
+                                        &features_ipv6,
+                                        &flow_map_ipv6,
+                                        ts_instant,
+                                    );
                                 }
                             }
                         }
@@ -873,11 +897,21 @@ fn export(output: &String) {
 /// * `data` - Basic features of the packet.
 /// * `flow_map` - Map of flows.
 /// * `fwd` - Direction of the packet.
-fn process_packet_ipv4<T>(data: &BasicFeaturesIpv4, flow_map: &Arc<DashMap<String, T>>, fwd: bool)
-where
+/// * `timestamp` - Timestamp of the packet.
+fn process_packet_ipv4<T>(
+    data: &BasicFeaturesIpv4,
+    flow_map: &Arc<DashMap<String, T>>,
+    fwd: bool,
+    timestamp: Option<Instant>,
+) where
     T: Flow,
 {
-    let timestamp = Instant::now();
+    let ts;
+    if let Some(timestamp) = timestamp {
+        ts = timestamp;
+    } else {
+        ts = Instant::now();
+    }
     let destination = std::net::IpAddr::V4(Ipv4Addr::from(u32::from_le_bytes(
         data.ipv4_source
             .to_be_bytes()
@@ -947,7 +981,7 @@ where
         }
     });
 
-    let end = entry.update_flow(&features, &timestamp, fwd);
+    let end = entry.update_flow(&features, &ts, fwd);
     if end.is_some() {
         export(&end.unwrap());
         drop(entry);
@@ -962,11 +996,21 @@ where
 /// * `data` - Basic features of the packet.
 /// * `flow_map` - Map of flows.
 /// * `fwd` - Direction of the packet.
-fn process_packet_ipv6<T>(data: &BasicFeaturesIpv6, flow_map: &Arc<DashMap<String, T>>, fwd: bool)
-where
+/// * `timestamp` - Timestamp of the packet.
+fn process_packet_ipv6<T>(
+    data: &BasicFeaturesIpv6,
+    flow_map: &Arc<DashMap<String, T>>,
+    fwd: bool,
+    timestamp: Option<Instant>,
+) where
     T: Flow,
 {
-    let timestamp = Instant::now();
+    let ts;
+    if let Some(timestamp) = timestamp {
+        ts = timestamp;
+    } else {
+        ts = Instant::now();
+    }
     let destination = std::net::IpAddr::V6(Ipv6Addr::from(data.ipv6_destination));
     let source = std::net::IpAddr::V6(Ipv6Addr::from(data.ipv6_source));
     let combined_flags = data.combined_flags;
@@ -1027,7 +1071,7 @@ where
         }
     });
 
-    let end = entry.update_flow(&features, &timestamp, fwd);
+    let end = entry.update_flow(&features, &ts, fwd);
     if end.is_some() {
         export(&end.unwrap());
         drop(entry);
@@ -1041,8 +1085,12 @@ where
 ///
 /// * `features_ipv4` - Basic features of the packet.
 /// * `flow_map` - Map of flows.
-fn redirect_packet_ipv4<T>(features_ipv4: &BasicFeaturesIpv4, flow_map: &Arc<DashMap<String, T>>)
-where
+/// * `timestamp` - Timestamp of the packet.
+fn redirect_packet_ipv4<T>(
+    features_ipv4: &BasicFeaturesIpv4,
+    flow_map: &Arc<DashMap<String, T>>,
+    timestamp: Instant,
+) where
     T: Flow,
 {
     let fwd_flow_id = create_flow_id(
@@ -1061,11 +1109,11 @@ where
     );
 
     if flow_map.contains_key(&fwd_flow_id) {
-        process_packet_ipv4(&features_ipv4, &flow_map, true);
+        process_packet_ipv4(&features_ipv4, &flow_map, true, Some(timestamp));
     } else if flow_map.contains_key(&bwd_flow_id) {
-        process_packet_ipv4(&features_ipv4, &flow_map, false);
+        process_packet_ipv4(&features_ipv4, &flow_map, false, Some(timestamp));
     } else {
-        process_packet_ipv4(&features_ipv4, &flow_map, true);
+        process_packet_ipv4(&features_ipv4, &flow_map, true, Some(timestamp));
     }
 }
 
@@ -1075,8 +1123,12 @@ where
 ///
 /// * `features_ipv6` - Basic features of the packet.
 /// * `flow_map` - Map of flows.
-fn redirect_packet_ipv6<T>(features_ipv6: &BasicFeaturesIpv6, flow_map: &Arc<DashMap<String, T>>)
-where
+/// * `timestamp` - Timestamp of the packet.
+fn redirect_packet_ipv6<T>(
+    features_ipv6: &BasicFeaturesIpv6,
+    flow_map: &Arc<DashMap<String, T>>,
+    timestamp: Instant,
+) where
     T: Flow,
 {
     let fwd_flow_id = create_flow_id(
@@ -1095,11 +1147,11 @@ where
     );
 
     if flow_map.contains_key(&fwd_flow_id) {
-        process_packet_ipv6(&features_ipv6, &flow_map, true);
+        process_packet_ipv6(&features_ipv6, &flow_map, true, Some(timestamp));
     } else if flow_map.contains_key(&bwd_flow_id) {
-        process_packet_ipv6(&features_ipv6, &flow_map, false);
+        process_packet_ipv6(&features_ipv6, &flow_map, false, Some(timestamp));
     } else {
-        process_packet_ipv6(&features_ipv6, &flow_map, true);
+        process_packet_ipv6(&features_ipv6, &flow_map, true, Some(timestamp));
     }
 }
 
@@ -1241,6 +1293,10 @@ fn extract_ipv6_features(ipv6_packet: &Ipv6Packet) -> Option<BasicFeaturesIpv6> 
     ))
 }
 
+fn timeval_to_system_time(tv_sec: i64, tv_usec: i64) -> SystemTime {
+    UNIX_EPOCH + Duration::new(tv_sec as u64, (tv_usec * 1000) as u32)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1263,7 +1319,7 @@ mod tests {
             _padding: [0; 3],
         };
 
-        process_packet_ipv4::<CicFlow>(&data_1, &flow_map, true);
+        process_packet_ipv4::<CicFlow>(&data_1, &flow_map, true, None);
 
         assert_eq!(flow_map.len(), 1);
 
@@ -1280,7 +1336,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_2, &flow_map, false);
+        process_packet_ipv4(&data_2, &flow_map, false, None);
 
         assert_eq!(flow_map.len(), 1);
         // 17 is for udp, here we just use it to create a new flow
@@ -1297,7 +1353,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_3, &flow_map, true);
+        process_packet_ipv4(&data_3, &flow_map, true, None);
 
         assert_eq!(flow_map.len(), 2);
 
@@ -1314,7 +1370,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_4, &flow_map, true);
+        process_packet_ipv4(&data_4, &flow_map, true, None);
 
         assert_eq!(flow_map.len(), 2);
 
@@ -1331,7 +1387,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_5, &flow_map, false);
+        process_packet_ipv4(&data_5, &flow_map, false, None);
 
         assert_eq!(flow_map.len(), 2);
 
@@ -1348,7 +1404,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_6, &flow_map, true);
+        process_packet_ipv4(&data_6, &flow_map, true, None);
 
         assert_eq!(flow_map.len(), 1);
 
@@ -1365,7 +1421,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_7, &flow_map, false);
+        process_packet_ipv4(&data_7, &flow_map, false, None);
 
         assert_eq!(flow_map.len(), 0);
 
@@ -1382,7 +1438,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_8, &flow_map, true);
+        process_packet_ipv4(&data_8, &flow_map, true, None);
 
         assert_eq!(flow_map.len(), 1);
 
@@ -1399,7 +1455,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_9, &flow_map, true);
+        process_packet_ipv4(&data_9, &flow_map, true, None);
 
         assert_eq!(flow_map.len(), 1);
 
@@ -1417,7 +1473,7 @@ mod tests {
             _padding: [0; 3],
         };
 
-        process_packet_ipv4(&data_10, &flow_map, true);
+        process_packet_ipv4(&data_10, &flow_map, true, None);
 
         assert_eq!(flow_map.len(), 1);
 
@@ -1434,7 +1490,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_11, &flow_map, false);
+        process_packet_ipv4(&data_11, &flow_map, false, None);
 
         assert_eq!(flow_map.len(), 1);
 
@@ -1451,7 +1507,7 @@ mod tests {
             window_size: 1000,
             _padding: [0; 3],
         };
-        process_packet_ipv4(&data_12, &flow_map, false);
+        process_packet_ipv4(&data_12, &flow_map, false, None);
 
         assert_eq!(flow_map.len(), 0);
     }


### PR DESCRIPTION
This change uses the timestamp of the added pcap header of the packet. It is converted to systemTime and then to the Instant type. This should be tested first :test_tube: !

closes #44 